### PR TITLE
Fix arm64 build flakiness + BLAS thread oversubscription

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -73,24 +73,41 @@ jobs:
         with:
           images: ${{ env.IMAGE }}
 
-      - name: Build and push digest
+      # Wrapped in nick-fields/retry as a belt-and-suspenders backstop: the
+      # Dockerfile already retries flaky conda-forge downloads internally, but if a
+      # whole build still dies (e.g. a transient registry/cache error) this restarts
+      # it. The gha cache rehydrates between attempts, so a retry resumes most of the
+      # work rather than rebuilding from scratch. Raw `docker buildx build` is used
+      # because nick-fields/retry runs a shell command, not a `uses:` action.
+      - name: Build and push digest (with retry)
         id: build
-        uses: docker/build-push-action@v6
+        uses: nick-fields/retry@v3
+        env:
+          LABELS: ${{ steps.meta.outputs.labels }}
         with:
-          context: .
-          file: ./Dockerfile
-          push: true
-          platforms: ${{ matrix.platform }}
-          labels: ${{ steps.meta.outputs.labels }}
-          # Push to a temporary digest (no tag yet — tags are applied in merge)
-          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          timeout_minutes: 90
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: |
+            label_args=()
+            while IFS= read -r line; do
+              [ -n "$line" ] && label_args+=(--label "$line")
+            done <<< "$LABELS"
+            docker buildx build \
+              --platform "${{ matrix.platform }}" \
+              --file ./Dockerfile \
+              "${label_args[@]}" \
+              --provenance=false \
+              --output "type=image,name=${IMAGE},push-by-digest=true,name-canonical=true,push=true" \
+              --cache-from type=gha \
+              --cache-to type=gha,mode=max \
+              --metadata-file /tmp/metadata.json \
+              .
 
       - name: Export digest
         run: |
           mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
+          digest=$(jq -r '."containerimage.digest"' /tmp/metadata.json)
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest artifact

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,16 @@ RUN echo "conda activate gospl-smoke" >> /etc/skel/.bashrc && \
 ENV FI_PROVIDER=tcp \
     MPICH_CH4_OFI_ENABLE=0
 
+# Threading defaults for the MPI-parallel solver. goSPL distributes work across
+# MPI ranks, so each rank must run single-threaded BLAS/OpenMP — otherwise every
+# rank spawns as many BLAS threads as there are cores and they oversubscribe the
+# CPU, making the container far slower than a native run. Control parallelism via
+# `mpirun -n <ranks>` instead. Override at runtime with `docker run -e OMP_NUM_THREADS=N`.
+ENV OMP_NUM_THREADS=1 \
+    OPENBLAS_NUM_THREADS=1 \
+    MKL_NUM_THREADS=1 \
+    NUMEXPR_NUM_THREADS=1
+
 WORKDIR /work
 EXPOSE 8888
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,18 @@ RUN conda config --system --set remote_read_timeout_secs 300 && \
     conda config --system --set remote_backoff_factor 5
 
 COPY environment.yml /tmp/environment.yml
-RUN mamba env create -f /tmp/environment.yml && \
+# Retry env creation: the conda-forge CDN occasionally drops large linux-aarch64
+# packages (e.g. pyarrow-core) mid-download, aborting the whole solve. The package
+# cache in /opt/conda/pkgs persists across attempts within this RUN layer, so each
+# retry only re-fetches what is still missing and eventually completes.
+RUN n=0; \
+    until mamba env create -f /tmp/environment.yml; do \
+        n=$((n+1)); \
+        if [ "$n" -ge 6 ]; then echo "mamba env create failed after $n attempts" >&2; exit 1; fi; \
+        echo "mamba env create failed; retry $n/6 in 15s..." >&2; \
+        sleep 15; \
+        rm -rf /opt/conda/envs/gospl-smoke; \
+    done && \
     mamba clean --all --yes && \
     find /opt/conda -follow -type f -name '*.pyc' -delete && \
     rm -f /tmp/environment.yml

--- a/README.md
+++ b/README.md
@@ -41,10 +41,11 @@ Once you have installed Docker on your system, pull the examples image:
 docker pull geodels/gospl-examples:latest
 ```
 
-> **Apple Silicon (M1/M2/M3) users.** The image is built for `linux/amd64` only. On Apple Silicon, add `--platform linux/amd64` to both the pull and run commands to use Rosetta 2 emulation. Alternatively, enable **Settings → General → Use Rosetta for x86_64/amd64 emulation on Apple Silicon** in Docker Desktop to make amd64 images work transparently without the flag.
+> **Apple Silicon (M1/M2/M3) users.** The image is published as a multi-arch manifest with **native `linux/arm64`** and `linux/amd64` builds, so a plain `docker pull` automatically selects the arm64 image on Apple Silicon — no `--platform` flag and no Rosetta emulation needed. Running the native arm64 image is **much faster** than forcing the amd64 image under emulation, so avoid adding `--platform linux/amd64` on Apple Silicon. You can confirm you got the native build with:
 >
 > ```bash
-> docker pull --platform linux/amd64 geodels/gospl-examples:latest
+> docker run --rm geodels/gospl-examples:latest python -c "import platform; print(platform.machine())"
+> # expect: aarch64 on Apple Silicon, x86_64 on Intel
 > ```
 
 ##### Starting the container from a terminal
@@ -57,7 +58,7 @@ cd goSPL-examples
 docker run -it --rm -p 8888:8888 -v "$PWD":/work geodels/gospl-examples:latest
 ```
 
-> **Apple Silicon users:** add `--platform linux/amd64` to the `docker run` command above.
+> **Apple Silicon users:** no `--platform` flag is needed — Docker pulls the native `linux/arm64` image automatically, which is significantly faster than amd64 emulation.
 
 JupyterLab will start and print a `http://127.0.0.1:8888/lab?token=…` URL — open it in your browser. The full repository is visible under `/work` and the `gospl-smoke` environment is already active (no `conda activate` needed).
 
@@ -91,6 +92,8 @@ mpirun -np 4 python runModel.py -i input-strati.yml
 ```
 
 The `gospl-smoke` environment is already on the `PATH` (no `conda activate` needed) and the MPI/libfabric TCP workaround is baked into the image. Change `-np 4` to the number of MPI ranks you want, and `-i` to the example's input file.
+
+> **Performance — threading.** The image defaults BLAS/OpenMP threads to 1 (`OMP_NUM_THREADS`, `OPENBLAS_NUM_THREADS`, `MKL_NUM_THREADS`, `NUMEXPR_NUM_THREADS`). goSPL gets its parallelism from MPI ranks (`mpirun -np N`), so single-threaded BLAS per rank avoids CPU oversubscription — leaving these unset lets every rank spawn one BLAS thread per core, which can make the container *much* slower than a native run. Set `-np` to the number of physical cores you want to use. For a non-MPI, single-process numpy/numba workload you can re-enable threading with e.g. `docker run -e OMP_NUM_THREADS=8 ...`. Also make sure Docker Desktop is allocated enough CPUs/RAM (Settings → Resources).
 
 #### Quick end-to-end test (no notebook required)
 


### PR DESCRIPTION
## Summary

Three related fixes for the Docker image build and runtime performance:

1. **Resilient arm64 builds** — the `linux/arm64` build was hanging on partial/timed-out conda-forge downloads of large packages (e.g. `pyarrow-core`), aborting the whole solve.
   - `Dockerfile`: retry `mamba env create` (up to 6 attempts) within a single `RUN` layer so the package cache persists and each retry only re-fetches what's still missing.
   - `docker-build.yml`: wrap the build in `nick-fields/retry` as a whole-build backstop, using raw `docker buildx build` (the retry action runs a shell command, not a `uses:` action). Digest now read from a metadata file; `--provenance=false` keeps the digest clean for the multi-arch merge.

2. **Fix runtime slowness (BLAS thread oversubscription)** — goSPL parallelises across MPI ranks, so each rank must run single-threaded BLAS/OpenMP; otherwise every rank spawns one BLAS thread per core and they oversubscribe the CPU, making the container far slower than a native run.
   - `Dockerfile`: set `OMP_NUM_THREADS` / `OPENBLAS_NUM_THREADS` / `MKL_NUM_THREADS` / `NUMEXPR_NUM_THREADS` to 1 as overridable defaults. Arch-safe (the MKL var is a no-op on arm64).

3. **README updates**
   - Replace the stale "linux/amd64 only / use Rosetta" note: the image is now a native multi-arch manifest, so Apple Silicon pulls arm64 automatically and emulation should be avoided.
   - Document the single-threaded BLAS/OpenMP defaults and how to re-enable threading for non-MPI workloads.

## Test plan
- [ ] Trigger the workflow (release tag or `workflow_dispatch`) and confirm both `linux/amd64` and `linux/arm64` build and merge.
- [ ] `docker run --rm geodels/gospl-examples:latest python -c "import platform; print(platform.machine())"` returns the native arch.
- [ ] Confirm an MPI example runs at expected speed with the new threading defaults.